### PR TITLE
In AccountAPI.get_quotas(), request more than the default 50 lines

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ ChangeLog
 
 * Target tests on Python 3.7 and 3.8-dev.
 * Remove Python 3.3 support.
+* In AccountAPI.get_quotas(), request more than the default 50 lines, quick fix of CP-1660
 
 
 `1.7.0 (2018-12-14) <https://github.com/scaleway/python-scaleway/compare/v1.6.0...v1.7.0>`_

--- a/scaleway/apis/api_account.py
+++ b/scaleway/apis/api_account.py
@@ -164,7 +164,10 @@ class AccountAPI(API):
     def get_quotas(self, organization):
         """ Gets a list of quotas for the given organization.
         """
-        response = self.query().organizations(organization).quotas.get()
+        # For now, request more than the default 50 lines
+        # TODO: improve this, cf: CP-1660
+        response = self.query().organizations(organization).quotas.get(
+            per_page=100)
         return response['quotas']
 
     def get_quota(self, organization, resource):


### PR DESCRIPTION
This is the quick fix of CP-1660