### PR TITLE
Add a short (ttl-based) cache to `AccountAPI.get_quotas()`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ ChangeLog
 `1.9.1 (unreleased) <https://github.com/scaleway/python-scaleway/compare/v1.9.0...develop>`_
 --------------------------------------------------------------------------------------------
 
-* No changes yet.
+* Add a short (ttl-based) cache to ``AccountAPI.get_quotas()``
 
 `1.9.0 (2019-07-03) <https://github.com/scaleway/python-scaleway/compare/v1.8.1...v1.9.0>`_
 --------------------------------------------------------------------------------------------

--- a/scaleway/apis/api_account.py
+++ b/scaleway/apis/api_account.py
@@ -10,6 +10,7 @@
 # License at https://opensource.org/licenses/BSD-2-Clause
 
 import slumber
+from cachetools.func import ttl_cache
 from six.moves import zip_longest
 
 from . import API
@@ -179,6 +180,7 @@ class AccountAPI(API):
                                include_locked=include_locked)
         )
 
+    @ttl_cache(maxsize=10, ttl=60)
     def get_quotas(self, organization):
         """ Gets a list of quotas for the given organization.
         """

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ MODULE_NAME = 'scaleway'
 PACKAGE_NAME = 'scaleway-sdk'
 
 DEPENDENCIES = [
+    'cachetools >= 3.1.1',
     'slumber >= 0.6.2',
     'six']
 


### PR DESCRIPTION
The goal is to optimize usecases like this :
```
api = AccountAPI(...)
api.has_quota(organization=organization, resource='servers', used=10)
api.has_quota(organization=organization, resource='volumes', used=10)
api.has_quota(organization=organization, resource='ips', used=10)
```
=> we check several quotas of the **same** organization in a very short period of time, typically within less than 1sec

In that usecase, the current AccountAPI does 3 calls to API-account, which is sub-optimal.
But we can easily cache "in-ram" the response to `get_quotas()`, because it's getting all quotas of a given organization, and re-use it for the 2nd and 3rd call.

NB: currently, each call to api-account to get quotas takes **~60 ms**, so each call avoided is a lot :)