### PR TITLE
fix: keep support for python 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,9 @@ MODULE_NAME = 'scaleway'
 PACKAGE_NAME = 'scaleway-sdk'
 
 DEPENDENCIES = [
-    'cachetools >= 3.1.1',
+    # last cachetools version supporting py2 is 3.1.1
+    'cachetools >= 3.1.1; python_version >= "3.0"',
+    'cachetools == 3.1.1; python_version < "3.0"',
     'slumber >= 0.6.2',
     'six']
 


### PR DESCRIPTION
cachetools recently drop py2 support, we would like to keep for some time so
simply use the latest py2 compatible cachetools when using py2. Py3 is free to
use the latest and greatest.